### PR TITLE
Feature/s3 integration

### DIFF
--- a/app/api/match/summary/route.ts
+++ b/app/api/match/summary/route.ts
@@ -20,7 +20,6 @@ import { sha256Hex } from "@/lib/hash";
 
 interface DifyRequestBody {
   inputs: {
-    resume_text: string;
     job_description: string;
   };
   response_mode: string;
@@ -61,41 +60,28 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    let resumeText: string | null = null;
-    let resumeHash: string | undefined = body.resumeHash as string | undefined;
+    // Resume text must be retrieved from S3
+    // 履歴書テキストはS3から取得する必要がある
+    if (!body.resumeId) {
+      return NextResponse.json({ error: "Missing resumeId" }, { status: 400 });
+    }
 
-    if (body.inputs?.resume_text) {
-      resumeText = body.inputs.resume_text.toString();
-      resumeHash = await sha256Hex(resumeText);
-    } else if (body.resumeId) {
-      // Try S3 if configured, otherwise require resume_text in request body
-      // S3が設定されている場合はS3から取得、そうでなければリクエストボディのresume_textが必要
-      if (isS3Configured()) {
-        resumeText = await getText(resumeKey(body.resumeId.toString()));
-        if (!resumeText) {
-          return NextResponse.json(
-            { error: "Resume not found in S3" },
-            { status: 404 }
-          );
-        }
-        resumeHash = await sha256Hex(resumeText);
-      } else {
-        // Development mode: require resume_text in request body
-        // 開発モード：リクエストボディにresume_textが必要
-        return NextResponse.json(
-          {
-            error:
-              "In development mode, resume_text must be provided in request body",
-          },
-          { status: 400 }
-        );
-      }
-    } else {
+    if (!isS3Configured()) {
       return NextResponse.json(
-        { error: "Missing resumeId or resume_text" },
-        { status: 400 }
+        { error: "S3 is not configured" },
+        { status: 500 }
       );
     }
+
+    const resumeText = await getText(resumeKey(body.resumeId.toString()));
+    if (!resumeText) {
+      return NextResponse.json(
+        { error: "Resume not found in S3" },
+        { status: 404 }
+      );
+    }
+
+    const resumeHash = await sha256Hex(resumeText);
 
     // 必须提供 Dify 配置
     // Dify 設定は必須

--- a/app/api/resume/route.ts
+++ b/app/api/resume/route.ts
@@ -36,27 +36,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // 开发模式：返回模拟数据，简历文本由前端保存到 sessionStorage
-    // 開発モード：モックデータを返す、履歴書テキストはフロントエンドで sessionStorage に保存
-    if (process.env.NODE_ENV === "development" && !process.env.ENABLE_S3_TEST) {
-      const resumeHash = "mock-hash-" + Date.now();
-      const resumeId = "mock-id-" + Date.now();
-
-      // 在开发模式下，简历文本由前端保存到 sessionStorage
-      // 開発モードでは、履歴書テキストはフロントエンドで sessionStorage に保存される
-      return NextResponse.json({
-        resumeId,
-        resumeHash,
-        resumeText, // 返回给前端，让前端保存到 sessionStorage
-      });
-    }
-
-    // 生产环境：实际存储到 S3
-    // 本番環境：実際にS3に保存
-    console.log("🚀 Storing resume to S3...");
-    console.log("📦 S3 Bucket:", process.env.AWS_S3_BUCKET);
-    console.log("🌍 AWS Region:", process.env.AWS_REGION);
-
     // Compute hash and generate a simple ID
     // ハッシュを計算し、簡易IDを生成
     const resumeHash = await sha256Hex(resumeText);

--- a/app/api/resume/route.ts
+++ b/app/api/resume/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     // 开发模式：返回模拟数据，简历文本由前端保存到 sessionStorage
     // 開発モード：モックデータを返す、履歴書テキストはフロントエンドで sessionStorage に保存
-    if (process.env.NODE_ENV === "development") {
+    if (process.env.NODE_ENV === "development" && !process.env.ENABLE_S3_TEST) {
       const resumeHash = "mock-hash-" + Date.now();
       const resumeId = "mock-id-" + Date.now();
 
@@ -53,15 +53,43 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     // 生产环境：实际存储到 S3
     // 本番環境：実際にS3に保存
+    console.log("🚀 Storing resume to S3...");
+    console.log("📦 S3 Bucket:", process.env.AWS_S3_BUCKET);
+    console.log("🌍 AWS Region:", process.env.AWS_REGION);
+
     // Compute hash and generate a simple ID
     // ハッシュを計算し、簡易IDを生成
     const resumeHash = await sha256Hex(resumeText);
     const resumeId = `${Date.now().toString(36)}-${resumeHash.slice(0, 12)}`;
 
+    console.log("💾 Resume ID:", resumeId);
+    console.log("🔑 Resume Hash:", resumeHash);
+    console.log("Resume Key:", resumeKey(resumeId));
+
     await putText(resumeKey(resumeId), resumeText);
+    console.log("✅ Resume stored to S3 successfully!");
 
     return NextResponse.json({ resumeId, resumeHash });
-  } catch {
+  } catch (error: unknown) {
+    // Log detailed error for debugging
+    // デバッグ用の詳細エラーログ
+    console.error("❌ S3 storage error:", error);
+
+    if (error instanceof Error) {
+      console.error("❌ Error type:", error.constructor.name);
+      console.error("❌ Error message:", error.message);
+    }
+
+    if (error && typeof error === "object") {
+      const errorObj = error as Record<string, unknown>;
+      if ("code" in errorObj) {
+        console.error("❌ Error code:", errorObj.code);
+      }
+      if ("$metadata" in errorObj) {
+        console.error("❌ AWS metadata:", errorObj.$metadata);
+      }
+    }
+
     // Avoid echoing sensitive text; return minimal error
     // 機密テキストを返さず、最小限のエラーのみ
     return NextResponse.json(

--- a/app/jobs/[id]/charts.tsx
+++ b/app/jobs/[id]/charts.tsx
@@ -45,12 +45,10 @@ interface DetailsEnvelope {
 
 export default function ClientCharts({
   resumeId,
-  resumeHash,
   jobId,
   jobDescription,
 }: {
   resumeId: string;
-  resumeHash: string;
   jobId: string;
   jobDescription: string;
 }): React.JSX.Element {
@@ -100,7 +98,6 @@ export default function ClientCharts({
             user: "Virginia Zhang",
             jobId,
             resumeId,
-            resumeHash,
           }),
           timeoutMs: 90000, // 90 seconds for Dify API processing
         });
@@ -115,7 +112,7 @@ export default function ClientCharts({
     }
 
     fetchSummary();
-  }, [resumeId, resumeHash, jobId, jobDescription]);
+  }, [resumeId, jobId, jobDescription]);
 
   // Fetch details data only after summary is completed
   // サマリー完了後にのみ詳細データを取得
@@ -167,7 +164,6 @@ export default function ClientCharts({
             user: "Virginia Zhang",
             jobId,
             resumeId,
-            resumeHash,
           }),
           timeoutMs: 90000, // 90 seconds for Dify API processing
         });
@@ -182,7 +178,7 @@ export default function ClientCharts({
     }
 
     fetchDetails();
-  }, [resumeId, resumeHash, jobId, jobDescription, summary]);
+  }, [resumeId, jobId, jobDescription, summary]);
 
   // Render summary section independently
   // サマリーセクションを独立してレンダリング
@@ -227,6 +223,13 @@ export default function ClientCharts({
         <div className="p-4 border border-red-200 bg-red-50 rounded-md">
           <h3 className="text-red-800 font-medium">サマリー分析エラー</h3>
           <p className="text-red-600 mt-1">{summaryError}</p>
+          <p className="text-xs text-muted-foreground mt-2">
+            履歴書が見つからない場合は、
+            <a href="/upload" className="underline">
+              アップロードページ
+            </a>
+            から再度アップロードしてください。
+          </p>
         </div>
       );
     }
@@ -400,6 +403,13 @@ export default function ClientCharts({
         <div className="p-4 border border-red-200 bg-red-50 rounded-md">
           <h3 className="text-red-800 font-medium">詳細分析エラー</h3>
           <p className="text-red-600 mt-1">{detailsError}</p>
+          <p className="text-xs text-muted-foreground mt-2">
+            履歴書が見つからない場合は、
+            <a href="/upload" className="underline">
+              アップロードページ
+            </a>
+            から再度アップロードしてください。
+          </p>
         </div>
       );
     }

--- a/app/jobs/[id]/client-detail-view.tsx
+++ b/app/jobs/[id]/client-detail-view.tsx
@@ -125,11 +125,9 @@ function serializeJDFromV2(j: JobDetailV2): string {
 export default function ClientDetailView({
   jobId,
   resumeId,
-  resumeHash,
 }: {
   jobId: string;
   resumeId: string;
-  resumeHash: string;
 }): React.ReactElement {
   const [detail, setDetail] = React.useState<JobDetailV2 | null>(null);
   const [loading, setLoading] = React.useState(true);
@@ -159,11 +157,10 @@ export default function ClientDetailView({
       // データがない場合は履歴書コンテキストを保持したまま一覧へ遷移
       const params = new URLSearchParams();
       if (resumeId) params.set("resumeId", resumeId);
-      if (resumeHash) params.set("resumeHash", resumeHash);
       const query = params.toString();
       router.push(`/jobs${query ? `?${query}` : ""}`);
     }
-  }, [loading, detail, resumeId, resumeHash, router]);
+  }, [loading, detail, resumeId, router]);
 
   if (loading) {
     return (
@@ -637,7 +634,6 @@ export default function ClientDetailView({
 
         <ClientCharts
           resumeId={resumeId}
-          resumeHash={resumeHash}
           jobId={jobId}
           jobDescription={serializeJDFromV2(detail)}
         />

--- a/app/jobs/[id]/page.tsx
+++ b/app/jobs/[id]/page.tsx
@@ -20,25 +20,18 @@ export default async function JobDetailPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams?: Promise<{ resumeId?: string; resumeHash?: string }>;
+  searchParams?: Promise<{ resumeId?: string }>;
 }) {
   const resolvedParams = await params;
   const resolvedSearchParams = await searchParams;
   const jobId = resolvedParams.id;
   const resumeId = resolvedSearchParams?.resumeId;
-  const resumeHash = resolvedSearchParams?.resumeHash;
 
-  // Strict flow guard: must have resumeId and resumeHash from upload flow
-  // 厳格なフローガード：アップロードフローから resumeId と resumeHash が必要
-  if (!resumeId || !resumeHash) {
+  // Strict flow guard: must have resumeId from upload flow
+  // 厳格なフローガード：アップロードフローから resumeId が必要
+  if (!resumeId) {
     redirect("/upload");
   }
 
-  return (
-    <ClientDetailView
-      jobId={jobId}
-      resumeId={resumeId}
-      resumeHash={resumeHash}
-    />
-  );
+  return <ClientDetailView jobId={jobId} resumeId={resumeId} />;
 }

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -14,12 +14,6 @@ import { fetchJobs, toListItem } from "@/lib/jobs";
 import SaveSelectedJobLink from "./SaveSelectedJobLink";
 import { redirect } from "next/navigation";
 
-/**
- * Client link that saves selected job detail into sessionStorage before navigation
- * 遷移前に選択した求人詳細をsessionStorageへ保存するクライアントリンク
- */
-// moved to client file SaveSelectedJobLink.tsx
-
 function timeAgo(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();
   const weeks = Math.floor(diff / (7 * 24 * 3600 * 1000));

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -23,15 +23,14 @@ function timeAgo(iso: string): string {
 export default async function JobsPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ resumeId?: string; resumeHash?: string }>;
+  searchParams?: Promise<{ resumeId?: string }>;
 }): Promise<React.JSX.Element> {
   const params = await searchParams;
   const resumeId = params?.resumeId;
-  const resumeHash = params?.resumeHash;
 
-  // Strict flow guard: must have resumeId and resumeHash from upload flow
-  // 厳格なフローガード：アップロードフローから resumeId と resumeHash が必要
-  if (!resumeId || !resumeHash) {
+  // Strict flow guard: must have resumeId from upload flow
+  // 厳格なフローガード：アップロードフローから resumeId が必要
+  if (!resumeId) {
     redirect("/upload");
   }
 
@@ -71,9 +70,7 @@ export default async function JobsPage({
               job={details.find(d => d.id === j.id)!}
               href={`/jobs/${encodeURIComponent(
                 j.id
-              )}?resumeId=${encodeURIComponent(
-                resumeId!
-              )}&resumeHash=${encodeURIComponent(resumeHash!)}`}
+              )}?resumeId=${encodeURIComponent(resumeId!)}`}
             >
               詳細を見る
             </SaveSelectedJobLink>

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -3,8 +3,8 @@
  * @description Minimal S3 JSON/Text helpers (Put/Get) using AWS SDK v3.
  * @description AWS SDK v3 を用いた最小限のS3 JSON/テキストのヘルパー（Put/Get）。
  * @author Virginia Zhang
- * @remarks Server-only. Reads env: AWS_REGION, S3_BUCKET, S3_PREFIX. Avoid client exposure.
- * @remarks サーバー専用。環境変数: AWS_REGION, S3_BUCKET, S3_PREFIX を読み取る。クライアントで公開しない。
+ * @remarks Server-only. Reads env: AWS_REGION, AWS_S3_BUCKET. Avoid client exposure.
+ * @remarks サーバー専用。環境変数: AWS_REGION, AWS_S3_BUCKET を読み取る。クライアントで公開しない。
  */
 
 import {
@@ -14,13 +14,13 @@ import {
 } from "@aws-sdk/client-s3";
 
 const REGION = process.env.AWS_REGION || "";
-const BUCKET = process.env.AWS_S3_BUCKET || process.env.S3_BUCKET || "";
+const BUCKET = process.env.AWS_S3_BUCKET || "";
 
 function assertServerEnv(): void {
   if (!REGION || !BUCKET) {
     // Ensure env is configured on server
     // サーバーで環境変数が設定されていることを確認
-    throw new Error("Missing AWS_REGION or S3_BUCKET env var");
+    throw new Error("Missing AWS_REGION or AWS_S3_BUCKET env var");
   }
 }
 

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -28,7 +28,12 @@ let _client: S3Client | null = null;
 function client(): S3Client {
   if (_client) return _client;
   assertServerEnv();
-  _client = new S3Client({ region: REGION });
+  _client = new S3Client({
+    region: REGION,
+    // Use path-style addressing for better compatibility
+    // より良い互換性のためにパススタイルアドレッシングを使用
+    forcePathStyle: true,
+  });
   return _client;
 }
 
@@ -41,6 +46,7 @@ export async function putText(
   text: string,
   contentType = "text/plain; charset=utf-8"
 ): Promise<void> {
+  console.log("🚀 Putting text to S3...");
   await client().send(
     new PutObjectCommand({
       Bucket: BUCKET,
@@ -52,8 +58,8 @@ export async function putText(
 }
 
 /**
- * @description Get UTF-8 text from S3.
- * @description S3からUTF-8テキストを取得。
+ * @description Get UTF-8 text from S3 or local storage as fallback.
+ * @description S3からUTF-8テキストを取得、フォールバックとしてローカルストレージ。
  */
 export async function getText(key: string): Promise<string | null> {
   try {
@@ -71,8 +77,8 @@ export async function getText(key: string): Promise<string | null> {
 }
 
 /**
- * @description Put JSON to S3.
- * @description JSONをS3へ保存。
+ * @description Put JSON to S3 or local storage as fallback.
+ * @description JSONをS3へ保存、フォールバックとしてローカルストレージ。
  */
 export async function putJson<T>(key: string, data: T): Promise<void> {
   const body = JSON.stringify(data);
@@ -80,8 +86,8 @@ export async function putJson<T>(key: string, data: T): Promise<void> {
 }
 
 /**
- * @description Get JSON from S3.
- * @description S3からJSONを取得。
+ * @description Get JSON from S3 or local storage as fallback.
+ * @description S3からJSONを取得、フォールバックとしてローカルストレージ。
  */
 export async function getJson<T>(key: string): Promise<T | null> {
   const body = await getText(key);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,76 @@
+/**
+ * @file storage.ts
+ * @description Client storage helpers for non-sensitive pointers (resumeId only).
+ * @description 機微情報ではないポインタ（resumeId のみ）を扱うクライアントストレージヘルパー。
+ * @author Virginia Zhang
+ * @remarks Browser-only. Never store resume_text or secrets.
+ * @remarks ブラウザ専用。resume_text や機密情報は保存しない。
+ */
+
+/**
+ * Helper to persist and retrieve current resume pointer.
+ * 現在の履歴書ポインタを保存・取得するヘルパー。
+ */
+export const resumePointer = {
+  key: "resume:current",
+  /**
+   * @description Save pointer to localStorage as JSON { resumeId, savedAt }.
+   * @description ポインタを { resumeId, savedAt } のJSONとして localStorage に保存。
+   * @param resumeId Resume identifier to persist / 保存する履歴書ID
+   */
+  save(resumeId: string): void {
+    if (typeof window === "undefined") return;
+    try {
+      const payload = {
+        resumeId,
+        savedAt: new Date().toLocaleString("ja-JP", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: false,
+        }),
+      };
+      window.localStorage.setItem(this.key, JSON.stringify(payload));
+    } catch {
+      // ignore
+    }
+  },
+  /**
+   * @description Load pointer from localStorage.
+   * @description localStorage からポインタを読み込み。
+   * @returns { resumeId: string; savedAt: number } | null Parsed pointer or null / パース済みポインタ、なければ null
+   * @returns { resumeId: string; savedAt: number } | null パース済みポインタ、なければ null
+   */
+  load(): { resumeId: string; savedAt: string } | null {
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = window.localStorage.getItem(this.key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as {
+        resumeId?: unknown;
+        savedAt?: unknown;
+      };
+      const resumeId = String(parsed.resumeId || "");
+      const savedAt = String(parsed.savedAt || "");
+      if (!resumeId || !savedAt) return null;
+      return { resumeId, savedAt };
+    } catch {
+      return null;
+    }
+  },
+  /**
+   * @description Clear stored pointer from localStorage.
+   * @description 保存されたポインタを localStorage から削除。
+   */
+  clear(): void {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(this.key);
+    } catch {
+      // ignore
+    }
+  },
+};


### PR DESCRIPTION
### Summary
This PR completes AWS S3 integration for the demo app. Sensitive data (resume text and AI match analysis results) is now persisted to S3, replacing the development-time use of `sessionStorage`.

### What’s Changed
- Store resume text in S3 on upload; server reads it back for analysis.
- Persist AI analysis results (summary/details) to S3 (cache by server-computed `resumeHash`).
- Remove client-side reliance on `sessionStorage` for sensitive data.
- Simplify client state: keep only `{ resumeId, savedAt }` pointer in localStorage.
- Navigation uses Next.js `router.push` (no `window.location*`).
- Jobs and detail pages guarded by `resumeId` only; `resumeHash` is not passed via URL.
- JP fallback notice added in charts when analysis errors occur (e.g., missing resume).

### Data Flow (High-level)
- Client uploads resume → Server saves plain text to S3 → Server retrieves, computes `resumeHash`, and calls LLM → Results are cached to S3 by `{jobId, phase, resumeHash}`.
- Client keeps a non-sensitive pointer `{ resumeId, savedAt }` for convenience.

### Security & Privacy
- No sensitive data in browser storage or URLs.
- All S3 access is server-side; keys remain on the server.
- Hash is derived server-side from S3 content and never trusted from the client.

### Testing Notes
- Upload a PDF/text resume → redirected to jobs with `resumeId`.
- Visiting job detail triggers summary then details; S3 cache is used transparently.
- Error paths show a JP notice with a link back to the upload page.

### Migration
- No breaking changes to the demo flow.
- Existing local `sessionStorage` entries are ignored going forward.
